### PR TITLE
Correct the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Here's an example of how you can use that function:
 
 ```php
 Required\Traduttore_Registry\add_project(
-	'plugin',
+	'plugins',
 	'example-plugin',
 	'https://translate.example.com/api/translations/acme/acme-plugin/'
 );
 
 Required\Traduttore_Registry\add_project(
-	'theme',
+	'themes',
 	'example-theme',
 	'https://translate.example.com/api/translations/acme/acme-theme/'
 );


### PR DESCRIPTION
`translations_api()` only accepts 'plugins', 'themes' and 'core' and the project type must match this.

I realized this when testing the new WP-CLI translation commands for themes on foodward.