### PR TITLE
Define $type with s in `translations_api` hook

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -27,7 +27,7 @@ function add_project( $type, $slug, $api_url ) {
 	add_filter(
 		'translations_api',
 		function ( $result, $requested_type, $args ) use ( $type, $slug, $api_url ) {
-			if ( $type === $requested_type && $slug === $args['slug'] ) {
+			if ( $type . 's' === $requested_type && $slug === $args['slug'] ) {
 				return get_translations( $type, $args['slug'], $api_url );
 			}
 


### PR DESCRIPTION
`translations_api()` only accepts 'plugins', 'themes' and 'core' and the project type must match this.

Tested using WP-CLI `2.0.1`.

- Clear cache `rm -rf /home/vagrant/.wp-cli/cache/translation/`
- Clear existing translations `~/wearerequired.local/foodward.ch/wordpress/content/languages/themes`
- Install theme translations `wp @dev theme list --field=name | xargs -I % wp @dev language theme install % de_DE`

Result the default theme translations will install correctly but that for "foodward-theme" will give an error "Error: Language 'de_DE' not found."

When using this patch the translations will be installed correctly.

Related: #7