### PR TITLE
Sanitize date header

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -187,7 +187,7 @@ function get_translations( $type, $slug, $url ) {
  * DateTime fails to parse date strings that contain brackets, such as
  * “Tue Dec 22 2015 12:52:19 GMT+0100 (West-Europa)”, which appears in
  * PO-Revision-Date headers. Sanitization ensures such date headers are
- * parsed correctly into DateTime objects.
+ * parsed correctly into DateTime instances.
  *
  * @since 2.1.0
  *

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -191,7 +191,7 @@ function get_translations( $type, $slug, $url ) {
  *
  * @since 2.1.0
  *
- * @param string $date_string
+ * @param string $date_string The date string to sanitize.
  *
  * @return \DateTime Date from string if parsable, otherwise the Unix epoch.
  */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -3,8 +3,6 @@
  * Main Traduttore Registry library.
  *
  * @since 1.0.0
- *
- * @package Required\Traduttore_Registry
  */
 
 namespace Required\Traduttore_Registry;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -203,7 +203,7 @@ function sanitize_date( $date_string ) {
 
 	try {
 		$date = new DateTime( $date_no_timezone );
-	} catch (Exception $e ) {
+	} catch ( \Exception $e ) {
 		return new DateTime( '1970-01-01' );
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,7 +79,7 @@ function add_project( $type, $slug, $api_url ) {
 				}
 
 				if ( $translation['updated'] && isset( $installed_translations[ $slug ][ $translation['language'] ] ) ) {
-					$local  = new DateTime( $installed_translations[ $slug ][ $translation['language'] ]['PO-Revision-Date'] );
+					$local  = sanitize_date( $installed_translations[ $slug ][ $translation['language'] ]['PO-Revision-Date'] );
 					$remote = new DateTime( $translation['updated'] );
 
 					if ( $local >= $remote ) {
@@ -181,4 +181,31 @@ function get_translations( $type, $slug, $url ) {
 
 	// Nothing found.
 	return [];
+}
+
+/**
+ * Sanitizes a date string.
+ *
+ * DateTime fails to parse date strings that contain brackets, such as
+ * “Tue Dec 22 2015 12:52:19 GMT+0100 (West-Europa)”, which appears in
+ * PO-Revision-Date headers. Sanitization ensures such date headers are
+ * parsed correctly into DateTime objects.
+ *
+ * @since 2.1.0
+ *
+ * @param string $date_string
+ *
+ * @return \DateTime Date from string if parsable, otherwise the Unix epoch.
+ */
+function sanitize_date( $date_string ) {
+	$date_and_timezone = explode( '(', $date_string );
+	$date_no_timezone  = trim( $date_and_timezone[0] );
+
+	try {
+		$date = new DateTime( $date_no_timezone );
+	} catch (Exception $e ) {
+		return new DateTime( '1970-01-01' );
+	}
+
+	return $date;
 }

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -81,9 +81,9 @@ class SanitizeDate extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for `test_good_dates_are_unaltered`.
+	 * Data provider for `test_bad_dates`.
 	 *
-	 * @return array Dates that should be unaltered after sanitization.
+	 * @return array Date strings that DateTime will throw an Exception for.
 	 */
 	function bad_dates() {
 		return [

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -16,8 +16,6 @@ use function \Required\Traduttore_Registry\sanitize_date;
  */
 class SanitizeDate extends WP_UnitTestCase {
 
-	private $result;
-
 	/**
 	 * Ensures good dates are unaltered.
 	 */

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -12,7 +12,7 @@ use \WP_UnitTestCase;
 use function \Required\Traduttore_Registry\sanitize_date;
 
 /**
- *  Tests dates by the sanitize_date() function.
+ *  Tests dates are sanitized by the `sanitize_date()` function.
  */
 class SanitizeDate extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -38,6 +38,18 @@ class SanitizeDate extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures date strings DateTime cannot parse fall back to the Unix epoch.
+	 *
+	 * @dataProvider bad_dates
+	 * @param string $date Unsanitized date string.
+	 */
+	public function test_bad_dates( $date ): void {
+		$epoch = new DateTime( '1970-01-01' );
+		$this->assertEquals( sanitize_date( $date ), $epoch );
+	}
+
+
+	/**
 	 * Data provider for `test_good_dates_are_unaltered`.
 	 *
 	 * @return array Dates that should be unaltered after sanitization.
@@ -68,4 +80,17 @@ class SanitizeDate extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Data provider for `test_good_dates_are_unaltered`.
+	 *
+	 * @return array Dates that should be unaltered after sanitization.
+	 */
+	function bad_dates() {
+		return [
+			['TBC'],
+			['123'],
+			['-'],
+			['The fifth of never.'],
+		];
+	}
 }

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -48,7 +48,6 @@ class SanitizeDate extends WP_UnitTestCase {
 		$this->assertEquals( $epoch, sanitize_date( $date ) );
 	}
 
-
 	/**
 	 * Data provider for `test_good_dates_are_unaltered`.
 	 *

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Class SanitizeDate
+ *
+ * @package Traduttore\Tests
+ */
+
+namespace Required\Traduttore_Registry\Tests;
+
+use DateTime;
+use \WP_UnitTestCase;
+use function \Required\Traduttore_Registry\sanitize_date;
+
+/**
+ *  Tests dates by the sanitize_date() function.
+ */
+class SanitizeDate extends WP_UnitTestCase {
+
+	private $result;
+
+	/**
+	 * Ensures good dates are unaltered.
+	 */
+	public function test_good_dates_are_unaltered(): void {
+		$good_dates = [
+			'2020-02-06 09:24:03+0000',
+			'2020-02-06 09:24:03',
+			'2020-02-06',
+		];
+
+		foreach	( $good_dates as $date ) {
+			$this->assertEquals( sanitize_date( $date ), new DateTime( $date ) );
+		}
+	}
+
+	/**
+	 * Ensures timezones are stripped.
+	 */
+	public function test_timezones_are_stripped(): void {
+		$dates_with_timezones = [
+			[
+				'input'    => 'Tue Jan 12 2016 15:04:22 GMT+0100 (Romance Standard Time)',
+				'expected' => 'Tue Jan 12 2016 15:04:22 GMT+0100'
+			],
+			[
+				'input'    => 'Tue Dec 22 2015 12:52:19 GMT+0100 (West-Europa)',
+				'expected' => 'Tue Dec 22 2015 12:52:19 GMT+0100',
+			],
+		];
+
+		foreach	( $dates_with_timezones as $date ) {
+			$this->assertEquals(
+				sanitize_date( $date['input'] ),
+				new DateTime( $date['expected'] )
+			);
+		}
+	}
+}

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -18,39 +18,54 @@ class SanitizeDate extends WP_UnitTestCase {
 
 	/**
 	 * Ensures good dates are unaltered.
+	 *
+	 * @dataProvider good_dates
+	 * @param string $date Unsanitized date string.
 	 */
-	public function test_good_dates_are_unaltered(): void {
-		$good_dates = [
-			'2020-02-06 09:24:03+0000',
-			'2020-02-06 09:24:03',
-			'2020-02-06',
-		];
-
-		foreach	( $good_dates as $date ) {
-			$this->assertEquals( sanitize_date( $date ), new DateTime( $date ) );
-		}
+	public function test_good_dates_are_unaltered( $date ): void {
+		$this->assertEquals( sanitize_date( $date ), new DateTime( $date ) );
 	}
 
 	/**
 	 * Ensures timezones are stripped.
+	 *
+	 * @dataProvider dates_with_timezones
+	 * @param string $date Unsanitized date string.
+	 * @param string $expected Expected result after sanitization.
 	 */
-	public function test_timezones_are_stripped(): void {
-		$dates_with_timezones = [
+	public function test_timezones_are_stripped( $date, $expected ): void {
+		$this->assertEquals( sanitize_date( $date ), new DateTime( $expected ) );
+	}
+
+	/**
+	 * Data provider for `test_good_dates_are_unaltered`.
+	 *
+	 * @return array Dates that should be unaltered after sanitization.
+	 */
+	function good_dates() {
+		return [
+			['2020-02-06 09:24:03+0000'],
+			['2020-02-06 09:24:03'],
+			['2020-02-06'],
+		];
+	}
+
+	/**
+	 * Data provider for `test_timezones_are_stripped`.
+	 *
+	 * @return array Unsanitized date and expected result pairs.
+	 */
+	function dates_with_timezones() {
+		return [
 			[
-				'input'    => 'Tue Jan 12 2016 15:04:22 GMT+0100 (Romance Standard Time)',
-				'expected' => 'Tue Jan 12 2016 15:04:22 GMT+0100'
+				'Tue Jan 12 2016 15:04:22 GMT+0100 (Romance Standard Time)',
+				'Tue Jan 12 2016 15:04:22 GMT+0100',
 			],
 			[
-				'input'    => 'Tue Dec 22 2015 12:52:19 GMT+0100 (West-Europa)',
-				'expected' => 'Tue Dec 22 2015 12:52:19 GMT+0100',
+				'Tue Dec 22 2015 12:52:19 GMT+0100 (West-Europa)',
+				'Tue Dec 22 2015 12:52:19 GMT+0100',
 			],
 		];
-
-		foreach	( $dates_with_timezones as $date ) {
-			$this->assertEquals(
-				sanitize_date( $date['input'] ),
-				new DateTime( $date['expected'] )
-			);
-		}
 	}
+
 }

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -23,7 +23,7 @@ class SanitizeDate extends WP_UnitTestCase {
 	 * @param string $date Unsanitized date string.
 	 */
 	public function test_good_dates_are_unaltered( $date ): void {
-		$this->assertEquals( sanitize_date( $date ), new DateTime( $date ) );
+		$this->assertEquals( new DateTime( $date ), sanitize_date( $date ) );
 	}
 
 	/**
@@ -34,7 +34,7 @@ class SanitizeDate extends WP_UnitTestCase {
 	 * @param string $expected Expected result after sanitization.
 	 */
 	public function test_timezones_are_stripped( $date, $expected ): void {
-		$this->assertEquals( sanitize_date( $date ), new DateTime( $expected ) );
+		$this->assertEquals( new DateTime( $expected ), sanitize_date( $date ) );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class SanitizeDate extends WP_UnitTestCase {
 	 */
 	public function test_bad_dates_give_unix_epoch( $date ): void {
 		$epoch = new DateTime( '1970-01-01' );
-		$this->assertEquals( sanitize_date( $date ), $epoch );
+		$this->assertEquals( $epoch, sanitize_date( $date ) );
 	}
 
 

--- a/tests/phpunit/tests/SanitizeDate.php
+++ b/tests/phpunit/tests/SanitizeDate.php
@@ -43,7 +43,7 @@ class SanitizeDate extends WP_UnitTestCase {
 	 * @dataProvider bad_dates
 	 * @param string $date Unsanitized date string.
 	 */
-	public function test_bad_dates( $date ): void {
+	public function test_bad_dates_give_unix_epoch( $date ): void {
 		$epoch = new DateTime( '1970-01-01' );
 		$this->assertEquals( sanitize_date( $date ), $epoch );
 	}
@@ -81,7 +81,7 @@ class SanitizeDate extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for `test_bad_dates`.
+	 * Data provider for `test_bad_dates_give_unix_epoch`.
 	 *
 	 * @return array Date strings that DateTime will throw an Exception for.
 	 */


### PR DESCRIPTION
Fixes #32 by ensuring that characters sometimes found in `PO-Revision-Date` headers such as '(' and ')' do not cause a fatal error.

The strategy as discussed in #32 is to:

- Use the date string up to the first '(' character.
- Fall back to the Unix epoch if the date still can not be parsed.

Catching `DateTime` construction with a fallback is not common (it's more common to just throw an exception if a provided date is bad). In this case it feels safer, though, because broken strings in translation files will otherwise cause WP sites to throw a fatal error during the translation update process.

An alternative would be to:

- Keep the logic around parsing the date before the first '('.
- Remove the try-catch block and only fix other DateTime parsing issues as we encounter them.